### PR TITLE
Add Special Projects tab and mobile contact details

### DIFF
--- a/about.html
+++ b/about.html
@@ -32,6 +32,7 @@
           <span class="logo-text">South Shore Land Solutions</span>
         </a>
         <nav class="nav-menu right-menu">
+          <a href="mailto:southshorelandsolutions@gmail.com" class="nav-link email">southshorelandsolutions@gmail.com</a>
           <a href="tel:12196284158" class="nav-link phone">(219)-628-4158</a>
           <a href="contact.html" class="nav-button">Get a Quote</a>
         </nav>

--- a/contact.html
+++ b/contact.html
@@ -32,6 +32,7 @@
           <span class="logo-text">South Shore Land Solutions</span>
         </a>
         <nav class="nav-menu right-menu">
+          <a href="mailto:southshorelandsolutions@gmail.com" class="nav-link email">southshorelandsolutions@gmail.com</a>
           <a href="tel:12196284158" class="nav-link phone">(219)-628-4158</a>
           <a href="contact.html" class="nav-button">Get a Quote</a>
         </nav>

--- a/gallery.html
+++ b/gallery.html
@@ -32,6 +32,7 @@
           <span class="logo-text">South Shore Land Solutions</span>
         </a>
         <nav class="nav-menu right-menu">
+          <a href="mailto:southshorelandsolutions@gmail.com" class="nav-link email">southshorelandsolutions@gmail.com</a>
           <a href="tel:12196284158" class="nav-link phone">(219)-628-4158</a>
           <a href="contact.html" class="nav-button">Get a Quote</a>
         </nav>

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
           <span class="logo-text">South Shore Land Solutions</span>
         </a>
         <nav class="nav-menu right-menu">
+          <a href="mailto:southshorelandsolutions@gmail.com" class="nav-link email">southshorelandsolutions@gmail.com</a>
           <a href="tel:12196284158" class="nav-link phone">(219)-628-4158</a>
           <a href="contact.html" class="nav-button">Get a Quote</a>
         </nav>

--- a/services.html
+++ b/services.html
@@ -32,6 +32,7 @@
           <span class="logo-text">South Shore Land Solutions</span>
         </a>
         <nav class="nav-menu right-menu">
+          <a href="mailto:southshorelandsolutions@gmail.com" class="nav-link email">southshorelandsolutions@gmail.com</a>
           <a href="tel:12196284158" class="nav-link phone">(219)-628-4158</a>
           <a href="contact.html" class="nav-button">Get a Quote</a>
         </nav>
@@ -65,8 +66,12 @@
         <h3>Site Preparation</h3>
         <p>We’ll clear, grade, and prep your site for any upcoming construction or landscaping. Dependable, on-time, and always quality-focused.</p>
       </div>
+      <div id="special-projects" class="service-card">
+        <div class="service-icon">🔧</div>
+        <h3>Special Projects</h3>
+        <p>Have a unique land or excavation project in mind? We handle custom work tailored to your needs.</p>
+      </div>
     </div>
-    <p style="margin-top: 32px;">Need something not listed? <a href="contact.html">Contact us</a> for a custom quote.</p>
   </div>
   <footer class="footer-section">
     <div class="footer-content">

--- a/style.css
+++ b/style.css
@@ -45,6 +45,9 @@ header.navbar {
   cursor: pointer;
   transition: color 0.2s;
 }
+.nav-link.email {
+  display: none;
+}
 .nav-link:hover,
 .dropdown-toggle:hover {
   color: #a1cd3a;
@@ -490,7 +493,7 @@ form button:hover {
 
 @media (max-width: 600px) {
   .menu-button { display: flex; }
-  .nav-menu {
+  .nav-menu.left-menu {
     display: none;
     position: absolute;
     top: 100%;
@@ -500,7 +503,10 @@ form button:hover {
     flex-direction: column;
     text-align: center;
   }
-  .nav-block.open .nav-menu { display: flex; }
+  .nav-block.open .nav-menu.left-menu { display: flex; }
+  .nav-menu.right-menu {
+    display: flex;
+  }
   .dropdown-list {
     position: static;
     box-shadow: none;
@@ -509,4 +515,5 @@ form button:hover {
   .nav-link,
   .dropdown-toggle,
   .nav-button { padding: 16px 20px; }
+  .nav-link.email { display: inline-block; }
 }


### PR DESCRIPTION
## Summary
- add a new **Special Projects** service card on Services page
- show email next to phone in the nav header
- keep contact info visible on mobile

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6852d683ff948330a43bae90fc3e96f8