### PR TITLE
Add either contact option & SEO updates

### DIFF
--- a/about.html
+++ b/about.html
@@ -13,11 +13,25 @@
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://southshorelandsolutions.com/about.html">
   <meta property="og:image" content="https://img.icons8.com/ios-filled/400/000000/construction-worker.png">
+  <meta property="og:site_name" content="South Shore Land Solutions">
+  <meta property="og:locale" content="en_US">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="author" content="South Shore Land Solutions">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Titillium+Web:wght@400;700&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "name": "South Shore Land Solutions",
+    "url": "https://southshorelandsolutions.com/about.html",
+    "telephone": "+1-219-628-4158",
+    "areaServed": "Northwest Indiana",
+    "description": "Land clearing, excavation and grading services"
+  }
+  </script>
 </head>
 <body>
   <div id="loader" class="loader"></div>

--- a/contact.html
+++ b/contact.html
@@ -13,11 +13,25 @@
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://southshorelandsolutions.com/contact.html">
   <meta property="og:image" content="https://img.icons8.com/ios-filled/400/000000/construction-worker.png">
+  <meta property="og:site_name" content="South Shore Land Solutions">
+  <meta property="og:locale" content="en_US">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="author" content="South Shore Land Solutions">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Titillium+Web:wght@400;700&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "name": "South Shore Land Solutions",
+    "url": "https://southshorelandsolutions.com/contact.html",
+    "telephone": "+1-219-628-4158",
+    "areaServed": "Northwest Indiana",
+    "description": "Request a quote for land clearing or excavation"
+  }
+  </script>
 </head>
 <body>
   <div id="loader" class="loader"></div>
@@ -60,6 +74,7 @@
       <option value="">Choose an option</option>
       <option value="phone">Phone</option>
       <option value="email">Email</option>
+      <option value="either">Either</option>
     </select>
 
     <label for="service-select">Service</label>

--- a/gallery.html
+++ b/gallery.html
@@ -13,11 +13,25 @@
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://southshorelandsolutions.com/gallery.html">
   <meta property="og:image" content="https://img.icons8.com/ios-filled/400/000000/construction-worker.png">
+  <meta property="og:site_name" content="South Shore Land Solutions">
+  <meta property="og:locale" content="en_US">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="author" content="South Shore Land Solutions">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Titillium+Web:wght@400;700&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "name": "South Shore Land Solutions",
+    "url": "https://southshorelandsolutions.com/gallery.html",
+    "telephone": "+1-219-628-4158",
+    "areaServed": "Northwest Indiana",
+    "description": "Photos of land management and excavation projects"
+  }
+  </script>
 </head>
 <body>
   <div id="loader" class="loader"></div>

--- a/index.html
+++ b/index.html
@@ -13,11 +13,25 @@
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://southshorelandsolutions.com/index.html">
   <meta property="og:image" content="https://img.icons8.com/ios-filled/400/000000/construction-worker.png">
+  <meta property="og:site_name" content="South Shore Land Solutions">
+  <meta property="og:locale" content="en_US">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="author" content="South Shore Land Solutions">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Titillium+Web:wght@400;700&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "name": "South Shore Land Solutions",
+    "url": "https://southshorelandsolutions.com/",
+    "telephone": "+1-219-628-4158",
+    "areaServed": "Northwest Indiana",
+    "description": "Land clearing, excavation, grading and driveway repair"
+  }
+  </script>
 </head>
 <body>
   <div id="loader" class="loader"></div>

--- a/script.js
+++ b/script.js
@@ -39,6 +39,9 @@ window.addEventListener('load', function () {
     } else if (contactMethod.value === 'email') {
       if (phoneInput) phoneInput.required = false;
       if (emailInput) emailInput.required = true;
+    } else if (contactMethod.value === 'either') {
+      if (phoneInput) phoneInput.required = false;
+      if (emailInput) emailInput.required = false;
     } else {
       if (phoneInput) phoneInput.required = false;
       if (emailInput) emailInput.required = false;
@@ -76,6 +79,12 @@ window.addEventListener('load', function () {
     quoteForm.addEventListener('submit', function(e) {
       e.preventDefault();
       var formMessage = document.getElementById('form-message');
+      if (contactMethod && contactMethod.value === 'either' && (!phoneInput.value && !emailInput.value)) {
+        if (formMessage) {
+          formMessage.textContent = 'Please provide a phone number or an email address.';
+        }
+        return;
+      }
       fetch(this.action, {
         method: 'POST',
         headers: { 'Accept': 'application/json' },

--- a/services.html
+++ b/services.html
@@ -13,11 +13,25 @@
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://southshorelandsolutions.com/services.html">
   <meta property="og:image" content="https://img.icons8.com/ios-filled/400/000000/construction-worker.png">
+  <meta property="og:site_name" content="South Shore Land Solutions">
+  <meta property="og:locale" content="en_US">
+  <meta name="twitter:card" content="summary_large_image">
   <meta name="author" content="South Shore Land Solutions">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Titillium+Web:wght@400;700&family=Raleway:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "LocalBusiness",
+    "name": "South Shore Land Solutions",
+    "url": "https://southshorelandsolutions.com/services.html",
+    "telephone": "+1-219-628-4158",
+    "areaServed": "Northwest Indiana",
+    "description": "Land clearing, excavation and site preparation services"
+  }
+  </script>
 </head>
 <body>
   <div id="loader" class="loader"></div>


### PR DESCRIPTION
## Summary
- let visitors choose phone, email, or either for contact
- validate either option on the quote form
- add Open Graph tags and Twitter card
- embed LocalBusiness schema for SEO

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_6852ec61bf7c83308790c183c39e576c